### PR TITLE
task(auth): harden middleware, secure nextauth, add auth smoke

### DIFF
--- a/apps/web/tests/smokes/auth-smoke.spec.ts
+++ b/apps/web/tests/smokes/auth-smoke.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+const EMAIL = process.env.E2E_CREDENTIALS_EMAIL;
+const PASSWORD = process.env.E2E_CREDENTIALS_PASSWORD;
+
+test('credentials -> /dashboard', async ({ page }) => {
+  test.skip(!EMAIL || !PASSWORD, 'E2E creds not set');
+  await page.goto('/login');
+  await page.fill('input[name="email"], #email', EMAIL!);
+  await page.fill('input[name="password"], #password', PASSWORD!);
+  await Promise.all([
+    page.waitForURL(/\/dashboard/),
+    page.click('button[type="submit"], button[data-testid="login-submit"]'),
+  ]);
+  await expect(page).toHaveURL(/\/dashboard/);
+});


### PR DESCRIPTION
## Summary
<!-- What changed & why -->

## Checks
- [ ] `/login` returns 200; no CSP console errors
- [ ] `/api/health` => `{ ok: true }`
- [ ] `/api/status` with Bearer token => `{ ok: true, env: "production" }`
- [ ] Screens/Lighthouse basics pass locally (labels, focus, color contrast)

## Summary
Explain what changed and why.

## Checks
- [ ] Images are served via `next/image` or `<img srcset>` with WebP/AVIF available.
- [ ] Critical font uses `next/font` (display: "swap"); no unused weights/styles.
- [ ] `/login` and `/dashboard` still pass Lighthouse gates locally (`pnpm verify:budgets`).
- [ ] Accessibility basics: labelled inputs, focus-visible, colour contrast, `<main>` landmark, no empty links/buttons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Playwright smoke test that logs in with env credentials and verifies redirect to `/dashboard`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d5bf61c3e2dab4e17bae65c6e1bb5339486a421. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->